### PR TITLE
Allow loading of redis dumps with binary data.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -68,6 +68,11 @@ For most sensitive data, you should consider encrypting the data directly withou
     
     # Decrypt the file (automated)
     $  3</path/2/passphrase.txt gpg --passphrase-fd 3 path/2/backup-db15.json.gpg
+
+
+== Loading data with binary strings
+
+If you have binary or serialized data in your Redis database, the YAJL parser may not load your dump file because it sees some of the binary data as 'invalid bytes in UTF8 string'.  If you are certain that your data is binary and not malformed UTF8, you can use the -n flag to redis-load to tell YAJL to not check the input for UTF8 validity.  Use with caution!
     
 == Installation
 

--- a/bin/redis-load
+++ b/bin/redis-load
@@ -28,6 +28,9 @@ class Redis::Dump::CLI
   global :u, :uri, String, "Redis URI (e.g. redis://hostname[:port])"
   global :d, :database, Integer, "Redis database (e.g. -d 15)"
   global :s, :sleep, Integer, "Sleep for S seconds after dumping (for debugging)"
+  global :n, :no_check_utf8 do
+    Redis::Dump.check_utf8 = false
+  end
   global :V, :version, "Display version" do 
     puts "redis-dump v#{Redis::Dump::VERSION.to_s}"
     exit 0

--- a/lib/redis/dump.rb
+++ b/lib/redis/dump.rb
@@ -27,6 +27,11 @@ class Redis
       def memory_usage
         `ps -o rss= -p #{Process.pid}`.to_i # in kb
       end
+      def check_utf8=(check)
+        if check == false
+          @parser = Yajl::Parser.new(:check_utf8 => false)
+        end
+      end
     end
     attr_accessor :dbs, :uri
     attr_reader :redis_connections


### PR DESCRIPTION
If the redis dump contains binary data (e.g. serialized data) that
appears to be invalid UTF8 to the YAJL parser, it will not load.
(https://github.com/delano/redis-dump/issues/7). I've added a "-n"
flag that will tell YAJL to ignore "bad utf8" in the case where the
user knows that their data is binary in nature.
