### PR TITLE
Now redis-dump work in Ruby 1.8.x

### DIFF
--- a/lib/redis/dump.rb
+++ b/lib/redis/dump.rb
@@ -78,7 +78,7 @@ class Redis
             process_chunk idx, dump_keys_size do |count|
               Redis::Dump.ld " dumping #{chunk_entries.size} (#{count}) from #{redis.client.id}"
               output_buffer = []
-              chunk_entries.select! do |key|
+              chunk_entries = chunk_entries.select do |key|
                 type = Redis::Dump.type(redis, key)
                 if self.class.with_optimizations && type == 'string'
                   true


### PR DESCRIPTION
$ ruby -v
ruby 1.8.7 (2012-02-08 patchlevel 358) [universal-darwin12.0]

$ redis-dump 
{"size":4,"ttl":-1,"key":"foo2,","type":"string","value":"bar2","db":0}
{"size":3,"ttl":-1,"key":"foo,","type":"string","value":"bar","db":0}
