### PR TITLE
Support redis-rb 5.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
+        fail-fast: true
         include:
           - ruby: '3.3'
             bundler: latest
@@ -23,6 +24,17 @@ jobs:
           - ruby: '3.2'
             bundler: latest
             rubygems: latest
+            redis: 5.2
+
+          - ruby: '3.2'
+            bundler: latest
+            rubygems: latest
+            redis: 4.7
+
+          - ruby: '3.2'
+            bundler: latest
+            rubygems: latest
+            redis: 4.8
 
           - ruby: '3.1'
             bundler: latest
@@ -65,7 +77,9 @@ jobs:
         bundler-cache: false
 
     - name: Re-run bundle install
-      run: bundle install
+      run: |
+        gem install redis --version ${{ matrix.redis }}
+        # bundle install
 
     - name: Run the tryouts
       run: bundle exec try -v try/*_try.rb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,12 +74,11 @@ jobs:
         # and cache the result automatically. Ran into an issue
         # with the caching and multiple ruby versions. Needs
         # further investigation.
-        bundler-cache: false
+        bundler-cache: true  # runs bundle install
 
     - name: Re-run bundle install
       run: |
         gem install redis --version ${{ matrix.redis }}
-        # bundle install
 
     - name: Run the tryouts
       run: bundle exec try -v try/*_try.rb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           - ruby: '3.0'
             bundler: latest
             rubygems: latest
-            redis: latest
+            redis: 5.2
 
           - ruby: '2.7'
             bundler: '2.4.22'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: "Ruby ${{ matrix.ruby }}${{ matrix.redis != null && matrix.redis != '' ? ' redis:' + matrix.redis : '' }}"
+    name: "Ruby ${{ matrix.ruby }} w/ redis:${{ matrix.redis }}"
     strategy:
       fail-fast: true
       matrix:
@@ -20,6 +20,7 @@ jobs:
           - ruby: '3.3'
             bundler: latest
             rubygems: latest
+            redis: latest
 
           - ruby: '3.2'
             bundler: latest
@@ -39,14 +40,17 @@ jobs:
           - ruby: '3.1'
             bundler: latest
             rubygems: latest
+            redis: latest
 
           - ruby: '3.0'
             bundler: latest
             rubygems: latest
+            redis: latest
 
           - ruby: '2.7'
             bundler: '2.4.22'
             rubygems: '3.2.3'
+            redis: latest
 
     services:
       redis:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
+      fail-fast: true
       matrix:
-        fail-fast: true
         include:
           - ruby: '3.3'
             bundler: latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: "Ruby ${{ matrix.ruby }}${{ matrix.redis != null && matrix.redis != '' ? ' redis:' + matrix.redis : '' }}"
     strategy:
       fail-fast: true
       matrix:
@@ -29,12 +29,12 @@ jobs:
           - ruby: '3.2'
             bundler: latest
             rubygems: latest
-            redis: 4.7
+            redis: 4.8
 
           - ruby: '3.2'
             bundler: latest
             rubygems: latest
-            redis: 4.8
+            redis: 4.7
 
           - ruby: '3.1'
             bundler: latest
@@ -76,7 +76,8 @@ jobs:
         # further investigation.
         bundler-cache: true  # runs bundle install
 
-    - name: Re-run bundle install
+    - name: Install redis gem @ ${{ matrix.redis }}
+      if: matrix.redis != ''
       run: |
         gem install redis --version ${{ matrix.redis }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           - ruby: '3.3'
             bundler: latest
             rubygems: latest
-            redis: latest
+            redis: 5.2
 
           - ruby: '3.2'
             bundler: latest
@@ -40,7 +40,7 @@ jobs:
           - ruby: '3.1'
             bundler: latest
             rubygems: latest
-            redis: latest
+            redis: 5.2
 
           - ruby: '3.0'
             bundler: latest
@@ -50,7 +50,7 @@ jobs:
           - ruby: '2.7'
             bundler: '2.4.22'
             rubygems: '3.2.3'
-            redis: latest
+            redis: 5.2
 
     services:
       redis:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,11 @@ REDIS-DUMP, CHANGES
 
 #### 0.6.0 (2024-06-17) ###############################
 
+* ADDED: Supports redis-rb 5.0
+* ADDED: Supports SSL via rediss://
+* CHANGED: Updated dependencies (see https://github.com/delano/redis-dump/pull/37)
+* FIXED: Resolved `sadd` warnings in redis 4.0 #35
+
 
 #### 0.5.0 (2023-01-17) ###############################
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "redis", ">= 4.0", "< 5.0"
+gem "drydock", ">= 0.6.9"
+gem "oj", ">= 3.16.4"
+gem "redis", ">= 4.0", "< 6.0"
 gem "uri-redis", ">= 1.3.0"
 gem "yajl-ruby", ">= 1.4.3"
-gem "oj", ">= 3.16.4"
-gem "drydock", ">= 0.6.9"
 
+gem "pry-byebug", "~> 3.10.1", require: false, group: :development
 gem "rake", "~> 13.0", require: false, group: :development
 gem "rubocop", "~> 1.64.1", require: false, group: :development
 gem "tryouts", "~> 2.2.0", require: false, group: :development
-gem "pry-byebug", "~> 3.10.1", require: false, group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
     bigdecimal (3.1.8)
     byebug (11.1.3)
     coderay (1.1.3)
+    connection_pool (2.4.1)
     drydock (0.6.9)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
@@ -24,7 +25,10 @@ GEM
     racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
-    redis (4.8.1)
+    redis (5.2.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.2)
+      connection_pool
     regexp_parser (2.9.2)
     rexml (3.3.0)
       strscan
@@ -62,7 +66,7 @@ DEPENDENCIES
   oj (>= 3.16.4)
   pry-byebug (~> 3.10.1)
   rake (~> 13.0)
-  redis (>= 4.0, < 5.0)
+  redis (>= 4.0, < 6.0)
   rubocop (~> 1.64.1)
   tryouts (~> 2.2.0)
   uri-redis (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Redis::Dump - v0.6
+# Redis::Dump - v0.6.0
 
 *Redis to JSON and back again. Dump and load Redis databases to/from JSON files.*
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Redis::Dump - v0.5 PRE
+# Redis::Dump - v0.6
 
-*Backup and restore your Redis data to and from JSON.*
+*Redis to JSON and back again. Dump and load Redis databases to/from JSON files.*
+
 
 ## Installation
 

--- a/lib/redis/dump/version.rb
+++ b/lib/redis/dump/version.rb
@@ -2,6 +2,6 @@
 
 class Redis
   class Dump
-    VERSION = "0.5.0-pre"
+    VERSION = "0.6.0"
   end
 end


### PR DESCRIPTION
This pull request updates the uri-redis dependency to version 1.0.0. It also includes the following changes:


- Support redis-rb 5.x
- Rubocop: order dependencies alphabetically
- Try adding redis gem versions to the matrix

Related to  #34, PR #37